### PR TITLE
Fix: Getting service file path for each service name from .tar file

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -1,6 +1,6 @@
 {
   "infuraKey": "1234567890",
   "network": "kovan",
-  "ipfsEndpoint": "https://ipfs.singularitynet.io:80",
+  "ipfsEndpoint": "http://ipfs.singularitynet.io:80",
   "port": 9000
 }


### PR DESCRIPTION
instead of assuming that filename will be the same as the service name
.proto.

Changed ipfs address in config sample to reflect that https is not being
used