### PR TITLE
Preserve snake_case while generating service spec jsons

### DIFF
--- a/app/service.js
+++ b/app/service.js
@@ -5,6 +5,7 @@ const os = require("os")
 const Web3 = require("web3")
 const klaw = require("klaw-sync")
 const protobuf = require("protobufjs")
+protobuf.parse.defaults.keepCase = true;
 
 const registryABI = require("singularitynet-platform-contracts/abi/Registry.json")
 const registryNetworks = require("singularitynet-platform-contracts/networks/Registry.json")


### PR DESCRIPTION
As reported by Abdulrahman Semrie

```
Hi everyone. So I was having issues with testing of the moses-service and annotation-service through the dApp lately. After much debugging, I found out the issue occurs when there is an underscore in a field name of a message in the *proto* definition of the service. In this case, the DApp sends an empty string for that field and this will trigger an error on the service side. To reproduce the issue  I have deployed two versions of the annotation service. The first which is named *annotation-service* has an underscore in the field names and it fails with an error. The second one named *annotation-service-test* has no underscore in any of the field names and it works as expected.

Here are the model hash for the services:
   - annotation-service: `-----------------------------------`
   - annotation-service-test: `---------------------------------`

This issue occurs only from the dApp and it works fine from the `snet cli`.
```
The DApp get the service definition from this service which in turn uses protobuf to load the proto files. Protobufjs by default converts snake_case to camelCase. See https://github.com/dcodeIO/protobuf.js/issues/564

In order to preserve case, proposing to set the global flag on protobufjs as described https://github.com/dcodeIO/protobuf.js/issues/608

@vforvalerio87 @tesYolan 